### PR TITLE
Fix log dir bug ; and ignore parent_metadata if necessary when displaying a processed dataset.

### DIFF
--- a/bioimageit_gui/experiment/_components.py
+++ b/bioimageit_gui/experiment/_components.py
@@ -660,7 +660,9 @@ class BiExperimentDataSetViewComponent(BiComponent):
             self.tableWidget.setItem(i, col_idx, QTableWidgetItem(raw_metadata.name))
             # origin
             col_idx  += 1
-            self.tableWidget.setItem(i, col_idx, QTableWidgetItem(parent_metadata.name))
+
+            if parent_metadata is not None:
+                self.tableWidget.setItem(i, col_idx, QTableWidgetItem(parent_metadata.name))
             # label
             col_idx  += 1
             self.tableWidget.setItem(i, col_idx, QTableWidgetItem(raw_metadata.output['label']))

--- a/bioimageit_gui/runner/_models.py
+++ b/bioimageit_gui/runner/_models.py
@@ -46,8 +46,9 @@ class BiRunnerModel(BiActuator):
     def run_file(self):
         self.thread.observer = self.observer
         self.thread.config_file = self.config_file
-        self.thread.log_dir = APIAccess.instance().log_observer.log_dir
-        self.thread.log_file_id = APIAccess.instance().log_observer.log_file_id
+        log_observer = APIAccess.instance().log_observer
+        self.thread.log_dir = log_observer.log_dir if log_observer is not None else None
+        self.thread.log_file_id = log_observer.log_file_id if log_observer is not None else None
         self.thread.mode = BiRunnerContainer.MODE_FILE
         self.thread.process_info = self.container.process_info
         self.thread.inputs = self.container.inputs
@@ -58,9 +59,9 @@ class BiRunnerModel(BiActuator):
     def run_exp(self):
         self.thread.observer = self.observer
         self.thread.config_file = self.config_file
-        if APIAccess.instance().log_observer is not None:
-            self.thread.log_dir = APIAccess.instance().log_observer.log_dir
-            self.thread.log_file_id = APIAccess.instance().log_observer.log_file_id
+        log_observer = APIAccess.instance().log_observer
+        self.thread.log_dir = log_observer.log_dir if log_observer is not None else None
+        self.thread.log_file_id = log_observer.log_file_id if log_observer is not None else None
         self.thread.experiment = self.container.experiment
         self.thread.mode = BiRunnerContainer.MODE_EXP
         self.thread.process_info = self.container.process_info
@@ -112,7 +113,8 @@ class BiRunnerThread(QThread):
 
             request = Request(self.config_file, False, False)
             request.job_count = self.job_count
-            request.add_log_observer(self.log_dir, self.log_file_id)
+            if self.log_dir is not None:
+                request.add_log_observer(self.log_dir, self.log_file_id)
             request.connect()
             request.exec(self.process_info, **params)    
 
@@ -129,7 +131,8 @@ class BiRunnerThread(QThread):
 
             request = Request(self.config_file, False, False)
             request.job_count = self.job_count
-            request.add_log_observer(self.log_dir, self.log_file_id)
+            if self.log_dir is not None:
+                request.add_log_observer(self.log_dir, self.log_file_id)
             request.connect()
             request.add_observer(self.observer)
             request.run(job)

--- a/bioimageit_gui/runner/_models.py
+++ b/bioimageit_gui/runner/_models.py
@@ -60,7 +60,7 @@ class BiRunnerModel(BiActuator):
         self.thread.config_file = self.config_file
         if APIAccess.instance().log_observer is not None:
             self.thread.log_dir = APIAccess.instance().log_observer.log_dir
-        self.thread.log_file_id = APIAccess.instance().log_observer.log_file_id
+            self.thread.log_file_id = APIAccess.instance().log_observer.log_file_id
         self.thread.experiment = self.container.experiment
         self.thread.mode = BiRunnerContainer.MODE_EXP
         self.thread.process_info = self.container.process_info


### PR DESCRIPTION
Fix log dir bug: ignore logs if log_dir (defined in `config.json`) is missing.
Ignore `parent_metadata` if necessary when displaying a processed dataset: in `drawProcessedDataSet()` (used to create the processed dataset browser of an experiment), the `parent_metadata` is None for certain types ; ignore (don't fill) the `Parent` column in this case.
